### PR TITLE
Adapt to MoPub iOS SDK 5.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # maio Mopub Mediation Adapter
 
+## Requirement
+
+- MoPubSDK 5.13.0+
+
 # Get Started
 
 ## Adding Maio to your MoPub Dashboard

--- a/objc/mopub.ObjectiveC/Podfile
+++ b/objc/mopub.ObjectiveC/Podfile
@@ -6,5 +6,5 @@ target 'mopub.ObjectiveC' do
   use_frameworks!
 
   # Pods for mopub.ObjectiveC
-  pod 'mopub-ios-sdk', '~> 5.12.0'
+  pod 'mopub-ios-sdk', '~> 5.13.0'
 end

--- a/objc/mopub.ObjectiveC/Podfile.lock
+++ b/objc/mopub.ObjectiveC/Podfile.lock
@@ -1,29 +1,23 @@
 PODS:
-  - mopub-ios-sdk (5.12.1):
-    - mopub-ios-sdk/MoPubSDK (= 5.12.1)
-  - mopub-ios-sdk/Avid (5.12.1):
+  - mopub-ios-sdk (5.13.0):
+    - mopub-ios-sdk/MoPubSDK (= 5.13.0)
+  - mopub-ios-sdk/Core (5.13.0)
+  - mopub-ios-sdk/MoPubSDK (5.13.0):
     - mopub-ios-sdk/Core
-  - mopub-ios-sdk/Core (5.12.1)
-  - mopub-ios-sdk/Moat (5.12.1):
-    - mopub-ios-sdk/Core
-  - mopub-ios-sdk/MoPubSDK (5.12.1):
-    - mopub-ios-sdk/Avid
-    - mopub-ios-sdk/Core
-    - mopub-ios-sdk/Moat
     - mopub-ios-sdk/NativeAds
-  - mopub-ios-sdk/NativeAds (5.12.1):
+  - mopub-ios-sdk/NativeAds (5.13.0):
     - mopub-ios-sdk/Core
 
 DEPENDENCIES:
-  - mopub-ios-sdk (~> 5.12.0)
+  - mopub-ios-sdk (~> 5.13.0)
 
 SPEC REPOS:
   trunk:
     - mopub-ios-sdk
 
 SPEC CHECKSUMS:
-  mopub-ios-sdk: d1640225b34ad74700e2acddb116cac634fc45d8
+  mopub-ios-sdk: 10865909734ce73d755dc23003a381497fbbb792
 
-PODFILE CHECKSUM: 02e73316c0470ee51f0b51ec606a43880da4c0bc
+PODFILE CHECKSUM: fd88946d253e6da94ac0c2e5ecd1cb5f12d29347
 
 COCOAPODS: 1.9.3

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioAdapterConfiguration.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioAdapterConfiguration.m
@@ -9,7 +9,7 @@
 #import "MaioAdapterConfiguration.h"
 #import <Maio/Maio.h>
 
-static NSString* const kMaioAdapterVersion = @"1.5.3.1";
+static NSString* const kMaioAdapterVersion = @"1.5.4.0";
 
 @implementation MaioAdapterConfiguration
 

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioAdapterConfiguration.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioAdapterConfiguration.m
@@ -9,7 +9,7 @@
 #import "MaioAdapterConfiguration.h"
 #import <Maio/Maio.h>
 
-static NSString* const kMaioAdapterVersion = @"1.5.3.0";
+static NSString* const kMaioAdapterVersion = @"1.5.3.1";
 
 @implementation MaioAdapterConfiguration
 

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
@@ -14,4 +14,7 @@
 /// Initialized by `MPFullscreenAdAdapter -init`
 @property (nonatomic, weak, readonly) id<MPFullscreenAdAdapterDelegate> delegate;
 
+/// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
+@property (nonatomic, copy) NSDictionary *localExtras;
+
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
@@ -11,9 +11,6 @@
 
 @interface MaioInterstitial : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
-/// Initialized by `MPFullscreenAdAdapter -init`
-@property (nonatomic, weak, readonly) id<MPFullscreenAdAdapterDelegate> delegate;
-
 /// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
 @property (nonatomic, copy) NSDictionary *localExtras;
 

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
@@ -11,4 +11,7 @@
 
 @interface MaioInterstitial : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
+/// Initialized by `MPFullscreenAdAdapter -init`
+@property (nonatomic, weak, readonly) id<MPFullscreenAdAdapterDelegate> delegate;
+
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
@@ -7,8 +7,8 @@
 
 #import <UIKit/UIKit.h>
 #import <Maio/Maio.h>
-#import "MPInterstitialCustomEvent.h"
+#import "MPFullscreenAdAdapter.h"
 
-@interface MaioInterstitial : MPInterstitialCustomEvent <MaioDelegate>
+@interface MaioInterstitial : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.h
@@ -11,7 +11,4 @@
 
 @interface MaioInterstitial : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
-/// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
-@property (nonatomic, copy) NSDictionary *localExtras;
-
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -21,6 +21,21 @@
 
 @implementation MaioInterstitial
 
+- (BOOL)isRewardExpected {
+    return NO;
+}
+
+- (BOOL)hasAdAvailable {
+    return [[MaioManager sharedInstance] canShowAtMediaId:self.credentials.mediaId zoneId:self.credentials.zoneId];
+}
+- (void)setHasAdAvailable:(BOOL)hasAdAvailable {
+    // NOOP
+}
+
+- (BOOL)enableAutomaticImpressionAndClickTracking {
+    return YES;
+}
+
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info {
     [self requestInterstitialWithCustomEventInfo:info adMarkup:nil];
 }

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -27,9 +27,7 @@
 
 /// Declared  by `MPFullscreenAdAdapter+Private.h`
 /// Initialized by `MPFullscreenAdAdapter -init`
-- (id<MPFullscreenAdAdapterDelegate>)delegate {
-    return super.delegate;
-}
+@dynamic delegate;
 
 - (BOOL)hasAdAvailable {
     MaioManager *manager = [MaioManager sharedInstance];

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -22,6 +22,10 @@
 @implementation MaioInterstitial
 
 /// Declared  by `MPFullscreenAdAdapter+Private.h`
+/// Initialized by `MPFullscreenAdAdapter -init`
+@dynamic delegate;
+
+/// Declared  by `MPFullscreenAdAdapter+Private.h`
 /// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
 @dynamic localExtras;
 
@@ -29,9 +33,6 @@
     return NO;
 }
 
-/// Declared  by `MPFullscreenAdAdapter+Private.h`
-/// Initialized by `MPFullscreenAdAdapter -init`
-@dynamic delegate;
 
 - (BOOL)hasAdAvailable {
     MaioManager *manager = [MaioManager sharedInstance];

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -27,7 +27,7 @@
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
     NSError *loadError = nil;
     if (![self canRequestWithCustomEventInfo:info error:&loadError]) {
-        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:loadError];
+        [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:loadError];
         MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:loadError], nil);
         return;
     }
@@ -50,12 +50,12 @@
 
     if ([manager isAdStockOut:_credentials.zoneId]) {
         NSError *adStockOutError = [MaioError loadFailedWithReason:MaioFailReasonAdStockOut];
-        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:adStockOutError];
+        [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:adStockOutError];
         MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:adStockOutError], nil);
     }
 
     if ([manager canShowAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId]) {
-        [self.delegate interstitialCustomEvent:self didLoadAd:self];
+        [self.delegate fullscreenAdAdapterDidLoadAd:self];
         MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     } else {
         _isAdRequested = YES;
@@ -88,11 +88,11 @@
     _isAdRequested = NO;
 
     if (newValue) {
-        [self.delegate interstitialCustomEvent:self didLoadAd:self];
+        [self.delegate fullscreenAdAdapterDidLoadAd:self];
         MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     } else {
         NSError *loadError = [MaioError loadFailed];
-        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:loadError];
+        [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:loadError];
         MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:loadError], _credentials.zoneId);
     }
 }
@@ -102,8 +102,8 @@
         return;
     }
 
-    [self.delegate interstitialCustomEventDidReceiveTapEvent:self];
-    [self.delegate interstitialCustomEventWillLeaveApplication:self];
+    [self.delegate fullscreenAdAdapterDidReceiveTap:self];
+    [self.delegate fullscreenAdAdapterWillLeaveApplication:self];
     MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adWillLeaveApplicationForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
 }
@@ -113,8 +113,8 @@
         return;
     }
 
-    [self.delegate interstitialCustomEventWillDisappear:self];
-    [self.delegate interstitialCustomEventDidDisappear:self];
+    [self.delegate fullscreenAdAdapterAdWillDisappear:self];
+    [self.delegate fullscreenAdAdapterAdDidDisappear:self];
     MPLogAdEvent([MPLogEvent adWillDisappearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adDidDisappearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
 }
@@ -124,8 +124,8 @@
         return;
     }
 
-    [self.delegate interstitialCustomEventWillAppear:self];
-    [self.delegate interstitialCustomEventDidAppear:self];
+    [self.delegate fullscreenAdAdapterAdWillAppear:self];
+    [self.delegate fullscreenAdAdapterAdDidAppear:self];
     MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
@@ -139,13 +139,13 @@
     if (reason == MaioFailReasonVideoPlayback) {
         NSError *playbackError = [MaioError loadFailedWithReason:reason];
         // MPInterstitialCustomEventDelegate has'nt didFailToPlayAdWithError
-        [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:playbackError];
+        [self.delegate fullscreenAdAdapter:self didFailToShowAdWithError:playbackError];
         MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:playbackError], _credentials.zoneId);
         return;
     }
 
     NSError *loadError = [MaioError loadFailedWithReason:reason];
-    [self.delegate interstitialCustomEvent:self didFailToLoadAdWithError:loadError];
+    [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:loadError];
     MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:loadError], _credentials.zoneId);
 }
 

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -12,10 +12,14 @@
 #import "MPLogging.h"
 #import "MoPub.h"
 
-@implementation MaioInterstitial {
-    MaioCredentials *_credentials;
-    BOOL _isAdRequested;
-}
+@interface MaioInterstitial ()
+
+@property (nonatomic) MaioCredentials *credentials;
+@property (nonatomic) BOOL isAdRequested;
+
+@end
+
+@implementation MaioInterstitial
 
 - (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info {
     [self requestInterstitialWithCustomEventInfo:info adMarkup:nil];

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -25,6 +25,12 @@
     return NO;
 }
 
+/// Declared  by `MPFullscreenAdAdapter+Private.h`
+/// Initialized by `MPFullscreenAdAdapter -init`
+- (id<MPFullscreenAdAdapterDelegate>)delegate {
+    return super.delegate;
+}
+
 - (BOOL)hasAdAvailable {
     return [[MaioManager sharedInstance] canShowAtMediaId:self.credentials.mediaId zoneId:self.credentials.zoneId];
 }

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -36,10 +36,7 @@
     return YES;
 }
 
-- (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info {
-    [self requestInterstitialWithCustomEventInfo:info adMarkup:nil];
-}
-- (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
+- (void)requestAdWithAdapterInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
     NSError *loadError = nil;
     if (![self canRequestWithCustomEventInfo:info error:&loadError]) {
         [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:loadError];
@@ -78,7 +75,7 @@
 
 }
 
-- (void)showInterstitialFromRootViewController:(UIViewController *)rootViewController {
+- (void)presentAdFromViewController:(UIViewController *)viewController {
     MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
 
     MaioManager *manager = [MaioManager sharedInstance];

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -21,6 +21,10 @@
 
 @implementation MaioInterstitial
 
+/// Declared  by `MPFullscreenAdAdapter+Private.h`
+/// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
+@dynamic localExtras;
+
 - (BOOL)isRewardExpected {
     return NO;
 }

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -32,7 +32,11 @@
 }
 
 - (BOOL)hasAdAvailable {
-    return [[MaioManager sharedInstance] canShowAtMediaId:self.credentials.mediaId zoneId:self.credentials.zoneId];
+    MaioManager *manager = [MaioManager sharedInstance];
+    if ([manager isAdStockOut:self.credentials.zoneId]) {
+        return NO;
+    }
+    return [manager canShowAtMediaId:self.credentials.mediaId zoneId:self.credentials.zoneId];
 }
 - (void)setHasAdAvailable:(BOOL)hasAdAvailable {
     // NOOP

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioInterstitial.m
@@ -80,7 +80,7 @@
 
     MaioManager *manager = [MaioManager sharedInstance];
     if (![manager canShowAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId]) return;
-    [manager showAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId];
+    [manager showAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId viewController:viewController];
 }
 
 - (BOOL)canRequestWithCustomEventInfo:(NSDictionary*)info error:(NSError**)errorPointer {

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.h
@@ -23,8 +23,6 @@
 
 - (BOOL)canShowAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId;
 
-- (void)showAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId;
-
 - (void)showAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId viewController: (UIViewController*) viewController;
 
 - (void)addDelegate:(id <MaioDelegate>)delegate forMediaId:(NSString *)mediaId;

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.h
@@ -25,5 +25,7 @@
 
 - (void)showAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId;
 
+- (void)showAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId viewController: (UIViewController*) viewController;
+
 - (void)addDelegate:(id <MaioDelegate>)delegate forMediaId:(NSString *)mediaId;
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.m
@@ -201,4 +201,13 @@
     [instance showAtZoneId:zoneId];
 }
 
+- (void)showAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId viewController: (UIViewController*) viewController {
+    if (!_references[mediaId]) {
+        return;
+    }
+
+    MaioInstance *instance = _references[mediaId];
+    [instance showAtZoneId:zoneId vc: viewController];
+}
+
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioManager.m
@@ -192,15 +192,6 @@
     return [instance canShowAtZoneId:zoneId];
 }
 
-- (void)showAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId {
-    if (!_references[mediaId]) {
-        return;
-    }
-
-    MaioInstance *instance = _references[mediaId];
-    [instance showAtZoneId:zoneId];
-}
-
 - (void)showAtMediaId:(NSString *)mediaId zoneId:(NSString *)zoneId viewController: (UIViewController*) viewController {
     if (!_references[mediaId]) {
         return;

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
@@ -14,4 +14,7 @@
 /// Initialized by `MPFullscreenAdAdapter -init`
 @property (nonatomic, weak, readonly) id<MPFullscreenAdAdapterDelegate> delegate;
 
+/// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
+@property (nonatomic, copy) NSDictionary *localExtras;
+
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
@@ -11,6 +11,4 @@
 
 @interface MaioRewardedVideo : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
-@property (nonatomic) BOOL hasAdAvailable;
-
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
@@ -11,9 +11,6 @@
 
 @interface MaioRewardedVideo : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
-/// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
-@property (nonatomic, copy) NSDictionary *localExtras;
-
 @property (nonatomic) BOOL hasAdAvailable;
 
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
@@ -7,8 +7,8 @@
 
 #import <Foundation/Foundation.h>
 #import <Maio/Maio.h>
-#import "MPRewardedVideoCustomEvent.h"
+#import "MPFullscreenAdAdapter.h"
 
-@interface MaioRewardedVideo : MPRewardedVideoCustomEvent <MaioDelegate>
+@interface MaioRewardedVideo : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
@@ -11,4 +11,7 @@
 
 @interface MaioRewardedVideo : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
+/// Initialized by `MPFullscreenAdAdapter -init`
+@property (nonatomic, weak, readonly) id<MPFullscreenAdAdapterDelegate> delegate;
+
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.h
@@ -11,10 +11,9 @@
 
 @interface MaioRewardedVideo : MPFullscreenAdAdapter <MPThirdPartyFullscreenAdAdapter, MaioDelegate>
 
-/// Initialized by `MPFullscreenAdAdapter -init`
-@property (nonatomic, weak, readonly) id<MPFullscreenAdAdapterDelegate> delegate;
-
 /// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
 @property (nonatomic, copy) NSDictionary *localExtras;
+
+@property (nonatomic) BOOL hasAdAvailable;
 
 @end

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -26,6 +26,12 @@
     return YES;
 }
 
+/// Declared  by `MPFullscreenAdAdapter+Private.h`
+/// Initialized by `MPFullscreenAdAdapter -init`
+- (id<MPFullscreenAdAdapterDelegate>)delegate {
+    return super.delegate;
+}
+
 - (BOOL)hasAdAvailable {
     MaioManager *manager = [MaioManager sharedInstance];
     if ([manager isAdStockOut:_credentials.zoneId]) {

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -28,9 +28,7 @@
 
 /// Declared  by `MPFullscreenAdAdapter+Private.h`
 /// Initialized by `MPFullscreenAdAdapter -init`
-- (id<MPFullscreenAdAdapterDelegate>)delegate {
-    return super.delegate;
-}
+@dynamic delegate;
 
 - (BOOL)hasAdAvailable {
     MaioManager *manager = [MaioManager sharedInstance];

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -33,7 +33,7 @@
 - (void)requestRewardedVideoWithCustomEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
     NSError* loadError = nil;
     if (![self canRequestWithCustomEventInfo:info error:&loadError]) {
-        [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:loadError];
+        [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:loadError];
         MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:loadError], nil);
         return;
     }
@@ -55,12 +55,12 @@
 
     if ([manager isAdStockOut:_credentials.zoneId]) {
         NSError *adStockOutError = [MaioError loadFailedWithReason:MaioFailReasonAdStockOut];
-        [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:adStockOutError];
+        [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:adStockOutError];
         MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:adStockOutError], nil);
     }
 
     if ([manager canShowAtMediaId:credentials.mediaId zoneId:credentials.zoneId]) {
-        [self.delegate rewardedVideoDidLoadAdForCustomEvent:self];
+        [self.delegate fullscreenAdAdapterDidLoadAd:self];
         MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     } else {
         _isAdRequested = YES;
@@ -107,7 +107,7 @@
     _isAdRequested = NO;
 
     if (newValue) {
-        [self.delegate rewardedVideoDidLoadAdForCustomEvent:self];
+        [self.delegate fullscreenAdAdapterDidLoadAd:self];
         MPLogAdEvent([MPLogEvent adLoadSuccessForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     }
 }
@@ -117,8 +117,8 @@
         return;
     }
 
-    [self.delegate rewardedVideoDidReceiveTapEventForCustomEvent:self];
-    [self.delegate rewardedVideoWillLeaveApplicationForCustomEvent:self];
+    [self.delegate fullscreenAdAdapterDidReceiveTap:self];
+    [self.delegate fullscreenAdAdapterWillLeaveApplication:self];
     MPLogAdEvent([MPLogEvent adTappedForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adWillLeaveApplicationForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
 }
@@ -128,8 +128,8 @@
         return;
     }
 
-    [self.delegate rewardedVideoWillAppearForCustomEvent:self];
-    [self.delegate rewardedVideoDidAppearForCustomEvent:self];
+    [self.delegate fullscreenAdAdapterAdWillAppear:self];
+    [self.delegate fullscreenAdAdapterAdDidAppear:self];
     MPLogAdEvent([MPLogEvent adWillAppearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adDidAppearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adShowSuccessForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
@@ -140,8 +140,8 @@
         return;
     }
 
-    [self.delegate rewardedVideoWillDisappearForCustomEvent:self];
-    [self.delegate rewardedVideoDidDisappearForCustomEvent:self];
+    [self.delegate fullscreenAdAdapterAdWillDisappear:self];
+    [self.delegate fullscreenAdAdapterAdDidDisappear:self];
     MPLogAdEvent([MPLogEvent adWillDisappearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     MPLogAdEvent([MPLogEvent adDidDisappearForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
 }
@@ -153,7 +153,7 @@
 
 
     MPRewardedVideoReward *reward = [[MPRewardedVideoReward alloc] initWithCurrencyAmount:@([rewardParam intValue])];
-    [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:reward];
+    [self.delegate fullscreenAdAdapter:self willRewardUser:reward];
 }
 
 - (void)maioDidFail:(NSString *)zoneId reason:(MaioFailReason)reason {
@@ -163,12 +163,12 @@
 
     if (reason == MaioFailReasonVideoPlayback) {
         NSError *playbackError = [MaioError loadFailedWithReason:reason];
-        [self.delegate rewardedVideoDidFailToPlayForCustomEvent:self error:playbackError];
+        [self.delegate fullscreenAdAdapter:self didFailToShowAdWithError:playbackError];
         MPLogAdEvent([MPLogEvent adShowFailedForAdapter:NSStringFromClass(self.class) error:playbackError], _credentials.zoneId);
         return;
     }
     NSError *loadError = [MaioError loadFailedWithReason:reason];
-    [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:loadError];
+    [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:loadError];
     MPLogAdEvent([MPLogEvent adLoadFailedForAdapter:NSStringFromClass(self.class) error:loadError], _credentials.zoneId);
 }
 

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -22,6 +22,25 @@
 
 @implementation MaioRewardedVideo
 
+- (BOOL)isRewardExpected {
+    return YES;
+}
+
+- (BOOL)hasAdAvailable {
+    MaioManager *manager = [MaioManager sharedInstance];
+    if ([manager isAdStockOut:_credentials.zoneId]) {
+        return NO;
+    }
+    return [manager canShowAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId];
+}
+- (void)setHasAdAvailable:(BOOL)hasAdAvailable {
+    // NOOP
+}
+
+- (BOOL)enableAutomaticImpressionAndClickTracking {
+    return YES;
+}
+
 - (void)initializeSdkWithParameters:(NSDictionary *)parameters {
     _credentials = [MaioCredentials credentialsFromDictionary:parameters];
     [self initializeMaioSdk];
@@ -77,13 +96,6 @@
     [manager startWithMediaId:_credentials.mediaId delegate:self];
 }
 
-- (BOOL)hasAdAvailable {
-    MaioManager *manager = [MaioManager sharedInstance];
-    if ([manager isAdStockOut:_credentials.zoneId]) {
-        return NO;
-    }
-    return [manager canShowAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId];
-}
 
 - (void)presentRewardedVideoFromViewController:(UIViewController *)viewController {
     MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -46,10 +46,7 @@
     [self initializeMaioSdk];
 }
 
-- (void)requestRewardedVideoWithCustomEventInfo:(NSDictionary *)info {
-    [self requestRewardedVideoWithCustomEventInfo:info adMarkup:nil];
-}
-- (void)requestRewardedVideoWithCustomEventInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
+- (void)requestAdWithAdapterInfo:(NSDictionary *)info adMarkup:(NSString *)adMarkup {
     NSError* loadError = nil;
     if (![self canRequestWithCustomEventInfo:info error:&loadError]) {
         [self.delegate fullscreenAdAdapter:self didFailToLoadAdWithError:loadError];
@@ -96,8 +93,7 @@
     [manager startWithMediaId:_credentials.mediaId delegate:self];
 }
 
-
-- (void)presentRewardedVideoFromViewController:(UIViewController *)viewController {
+- (void)presentAdFromViewController:(UIViewController *)viewController {
     MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
     [[MaioManager sharedInstance] showAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId];
 }

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -13,10 +13,14 @@
 #import "MPLogging.h"
 #import "MoPub.h"
 
-@implementation MaioRewardedVideo {
-    MaioCredentials *_credentials;
-    BOOL _isAdRequested;
-}
+@interface MaioRewardedVideo ()
+
+@property (nonatomic) MaioCredentials *credentials;
+@property (nonatomic) BOOL isAdRequested;
+
+@end
+
+@implementation MaioRewardedVideo
 
 - (void)initializeSdkWithParameters:(NSDictionary *)parameters {
     _credentials = [MaioCredentials credentialsFromDictionary:parameters];

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -23,16 +23,16 @@
 @implementation MaioRewardedVideo
 
 /// Declared  by `MPFullscreenAdAdapter+Private.h`
+/// Initialized by `MPFullscreenAdAdapter -init`
+@dynamic delegate;
+
+/// Declared  by `MPFullscreenAdAdapter+Private.h`
 /// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
 @dynamic localExtras;
 
 - (BOOL)isRewardExpected {
     return YES;
 }
-
-/// Declared  by `MPFullscreenAdAdapter+Private.h`
-/// Initialized by `MPFullscreenAdAdapter -init`
-@dynamic delegate;
 
 - (BOOL)hasAdAvailable {
     MaioManager *manager = [MaioManager sharedInstance];

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -95,7 +95,7 @@
 
 - (void)presentAdFromViewController:(UIViewController *)viewController {
     MPLogAdEvent([MPLogEvent adShowAttemptForAdapter:NSStringFromClass(self.class)], _credentials.zoneId);
-    [[MaioManager sharedInstance] showAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId];
+    [[MaioManager sharedInstance] showAtMediaId:_credentials.mediaId zoneId:_credentials.zoneId viewController:viewController];
 }
 
 - (BOOL)canRequestWithCustomEventInfo:(NSDictionary*)info error:(NSError**)errorPointer {

--- a/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
+++ b/objc/mopub.ObjectiveC/mopub.ObjectiveC/MaioMoPubAdapter/MaioRewardedVideo.m
@@ -22,6 +22,10 @@
 
 @implementation MaioRewardedVideo
 
+/// Declared  by `MPFullscreenAdAdapter+Private.h`
+/// Initialized by  `MPFullscreenAdAdapter -setUpWithAdConfiguration:localExtras:`
+@dynamic localExtras;
+
 - (BOOL)isRewardExpected {
     return YES;
 }


### PR DESCRIPTION
## Changed

- Update MoPubSDK to 5.13.0
- Extend `MPFullscreenAdAdapter`
- Implement `MPThirdPartyFullscreenAdAdapter`
    - Change signature to "FullscreenAd"

## Checked

### RewardVideo

- No problem with displaying ads
- No problem in invoking lifecycle event

### Interstital

- No problem with displaying ads
- No problem in invoking lifecycle event